### PR TITLE
modify list of parameters for sliders and inputs

### DIFF
--- a/ModelExplorer/modelexplorer.py
+++ b/ModelExplorer/modelexplorer.py
@@ -176,7 +176,9 @@ class SasModelApp(QMainWindow):
             self.parameters.clear()
 
             # Dynamically add sliders and input boxes for each model parameter
-            for parameter in self.model.info.parameters.common_parameters+self.model.info.parameters.kernel_parameters:
+            # XSB: 5.5.2025 change to iterate through model_parameters written in call_parameters instead of the info parameters. allows to load 'core_multi_shell'
+            # for parameter in self.model.info.parameters.common_parameters+self.model.info.parameters.kernel_parameters:
+            for parameter in self.model.info.parameters.common_parameters+self.model_info.parameters.call_parameters:
                 self.parameters[parameter.name] = parameter
                 # Add the parameter layout for the current parameter
                 param_layout = self.create_parameter_input_element(parameter)


### PR DESCRIPTION
wasn't able to load the core_multi_shell model as the list of parameters was loading the common nomenclature with sld[n] instead of sld1, sld2, sld3, etc.  changed that the list of paramters is loaded from model_info.parameters.call_parameters.

This way all parameters are listed which as a side effect also includes parameters that don't modify the displayed scattering profile.
Therefore, the list of paramters can get a bit crowded

Maybe this can be solved in a more elegant manner, but does the trick to also use core_multi_shell